### PR TITLE
Change expire request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+cnf.json
+URLshortener
+URLshortener-amd64

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # URLshortener
 [![CircleCI](https://circleci.com/gh/slytomcat/URLshortener.svg?style=svg)](https://circleci.com/gh/slytomcat/URLshortener)
-[![DeepSource](https://static.deepsource.io/deepsource-badge-light.svg)](https://deepsource.io/gh/slytomcat/URLshortener/?ref=repository-badge)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+
+[![DeepSource](https://static.deepsource.io/deepsource-badge-light.svg)](https://deepsource.io/gh/slytomcat/URLshortener/?ref=repository-badge)
 
 URLshortener is a micro-service to shorten long URLs and to handle the redirection by generated short URLs.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # URLshortener
 [![CircleCI](https://circleci.com/gh/slytomcat/URLshortener.svg?style=svg)](https://circleci.com/gh/slytomcat/URLshortener)
 [![DeepSource](https://static.deepsource.io/deepsource-badge-light.svg)](https://deepsource.io/gh/slytomcat/URLshortener/?ref=repository-badge)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
 URLshortener is a micro-service to shorten long URLs and to handle the redirection by generated short URLs.
 
@@ -17,14 +18,14 @@ Method: `POST`
 Request body: JSON with following parameters:
 
 - url: URL to shorten, mandatory
-- exp: short URL expiration in days, optional
+- exp: short URL expiration in days, optional, default: value of "DefaultExp" from configuration file
 
 Success response: HTTP 200 OK with body containing JSON with following parameters:
 
 - token: token for short URL
 - url: short URL
 
-### Request to expire token:
+### Request for set new expiration of token:
 
 URL: `<host>[:<port>]/api/v1/expire`
 
@@ -32,16 +33,17 @@ Method: `POST`
 
 Request body: JSON with following parameter:
 
-- token: token for short URL
+- token: token for short URL, mandatory.
+- exp: new expiration in days from now, optional. Default 0, value that marks token as expired. 
 
-Success response: HTTP 200 OK
+Success response: HTTP 200 OK with empty body
 
 ### Redirect to long URL:
 URL: `<host>[:<port>]/<token>` - URL from response on request for short URL
 
 Method: `GET`
 
-Response contain the redirection to long URL (response code: HTTP 301 'Moved permanently' with 'Location' = long URL in header)
+Response contain the redirection to long URL (response code: HTTP 301 'Moved permanently' with 'Location' = long URL in response header)
 
 ### Health-check:
 URL: `<host>[:<port>]/`
@@ -52,6 +54,8 @@ Response: simple home page and HTTP 200 OK in case of good service health or HTT
 
 
 ### Configuration file
+
+Configuration file must have a name `cnf.json` and it should be placed in the same folder where URLshortener was run. The file content must be the following correct JSON value: 
 
     {
 
@@ -71,12 +75,12 @@ Response: simple home page and HTTP 200 OK in case of good service health or HTT
 
 Where:
 
-- DSN - MySQL connection string (mandatory, also can set via URLSHORTENER_DSN environment variable)
-- MaxOpenConns - DataBase connections pool size (optional, default 10)
-- ListenHostPort - host and port to listen on (optional, default localhost:8080)
-- DefaultExp - default token expiration period in days (optional, default 1)
-- ShortDomain - short domain name for short URL creation (optional, default localhost:8080)
-- Mode - service mode (optional, default 0):
+- `DSN - MySQL` connection string (mandatory, also can set via URLSHORTENER_DSN environment variable)
+- `MaxOpenConns` - DataBase connections pool size (optional, default 10)
+- `ListenHostPort` - host and port to listen on (optional, default localhost:8080)
+- `DefaultExp` - default token expiration period in days (optional, default 1)
+- `ShortDomain` - short domain name for short URL creation (optional, default localhost:8080)
+- `Mode` - service mode (optional, default 0). Possible values:
 
    0 - service handles all requests
 
@@ -84,6 +88,6 @@ Where:
 
    2 - request for short URL is disabled
 
-   4 - request for token expiration is disabled
+   4 - request for set new expiration of token is disabled
 
-Mode value can be a sum of several modes, for example Mode=6 disables requests for short URL and for token expiration.
+Value of `Mode` can be a sum of several modes, for example `"Mode":"6"` disables two requests: request for short URL and request to set new expiration of token.

--- a/ShortToken.go
+++ b/ShortToken.go
@@ -1,9 +1,11 @@
 package main
 
-// ShortToken is string of 6 BASE64 symbols from the url safe alphabet.
-// It represent 36 bits of data. ShortToken is not correct BASE64 data
-// representation.
-// If you need longer/shorten token length adjust tokenLenS
+// ShortToken is string of tokenLenS BASE64 symbols from the url safe alphabet.
+// It represent 6*tokenLenS bits of data. ShortToken is not correct BASE64 data
+// representation as number of bits is not always a multiple of 8 (1 byte).
+
+// If you need longer/shorten token length adjust tokenLenS constant and `token`
+// field length in schema.sql file
 
 import (
 	"crypto/rand"

--- a/TokenDB_test.go
+++ b/TokenDB_test.go
@@ -121,7 +121,7 @@ func Test15NewTokenRace(t *testing.T) {
 
 // try to make token expired
 func Test20ExpireToken(t *testing.T) {
-	err := tDB.Expire(DEBUGToken)
+	err := tDB.Expire(DEBUGToken, -1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -144,11 +144,11 @@ func Test25GetToken(t *testing.T) {
 
 // try to prolong the token
 func Test27Prolong(t *testing.T) {
-	err := tDB.Expire(DEBUGToken)
+	err := tDB.Expire(DEBUGToken, -1)
 	if err != nil {
 		t.Error(err)
 	}
-	err = tDB.Prolong(DEBUGToken, 1)
+	err = tDB.Expire(DEBUGToken, 1)
 	if err != nil {
 		t.Error(err)
 	}

--- a/URLshortener.go
+++ b/URLshortener.go
@@ -71,7 +71,7 @@ func healthCheck() error {
 	// url for sef-check redirect
 	url := "http://" + CONFIG.ShortDomain + "/favicon.ico"
 
-	// replay parameters
+	// short URL request's replay parameters
 	var repl struct {
 		URL   string `json:"url"`
 		Token string `json:"token"`
@@ -80,7 +80,7 @@ func healthCheck() error {
 
 	// self-test part 1: get short URL
 	if CONFIG.Mode&disableShortener != 0 {
-		// use tokenDB inteface as web-interface is locked in this mode
+		// use tokenDB inteface as web-interface is locked in this service mode
 		if repl.Token, err = tokenDB.New(url, 1); err != nil {
 			return err
 		}
@@ -109,7 +109,7 @@ func healthCheck() error {
 
 	// self-test part 2: check redirect
 	if CONFIG.Mode&disableRedirect != 0 {
-		// use tokenDB interface as web-interface is locked in this mode
+		// use tokenDB interface as web-interface is locked in this service mode
 		if _, err = tokenDB.Get(repl.Token); err != nil {
 			return err
 		}
@@ -127,8 +127,9 @@ func healthCheck() error {
 		}
 	}
 
-	// self-test part 3: expire received token
+	// self-test part 3: make received token as expired
 	if CONFIG.Mode&disableExpire != 0 {
+		// use tokenDB interface as web-interface is locked in this service mode
 		if err := tokenDB.Expire(repl.Token, -1); err != nil {
 			return err
 		}
@@ -184,9 +185,9 @@ func redirect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// get the long URL
-	longURL, err := tokenDB.Get(r.URL.Path[1:])
+	longURL, err := tokenDB.Get(sToken)
 	if err != nil {
-		log.Printf("%s: token is not found\n", rMess)
+		log.Printf("%s: token was not found\n", rMess)
 		// send 404 response
 		http.NotFound(w, r)
 		return

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/slytomcat/URLshortener
 
 go 1.13
 
-require (
-	github.com/go-sql-driver/mysql v1.4.1
-	google.golang.org/appengine v1.6.5 // indirect
-)
+require github.com/go-sql-driver/mysql v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190603091049-60506f45cf65 h1:+rhAzEzT3f4JtomfC371qB+0Ola2caSKcY69NUBZrRQ=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
-google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=

--- a/schema.sql
+++ b/schema.sql
@@ -13,6 +13,10 @@ USE shortener_DB
 -- works independently on used timezone. But let it be UTC.  
 SET time_zone = '+00:00';
 
+
+-- If you need longer/shorten token length adjust `token` field
+-- length and tokenLenS constant in ShortToken.go file
+
 DROP TABLE IF EXISTS `urls`;
 CREATE TABLE `urls` (
   `token` CHAR(6) NOT NULL ,
@@ -30,6 +34,7 @@ CREATE USER `shortener`@`%` IDENTIFIED BY RANDOM PASSWORD;
 -- DELETE right required only for test purpose. Do not grant DELETE right in production environment.
 
 -- GRANT command for test environment:
---GRANT DELETE, SELECT, INSERT(`token`, `url`, `exp`), UPDATE(`token`, `url`, `exp`) ON `shortener_DB`.`urls` TO `shortener`@`%`;
+-- GRANT DELETE, SELECT, INSERT(`token`, `url`, `exp`), UPDATE(`token`, `url`, `exp`) ON `shortener_DB`.`urls` TO `shortener`@`%`;
+
 -- GRANT command for production environment:
 GRANT SELECT, INSERT(`token`, `url`, `exp`), UPDATE(`token`, `url`, `exp`) ON `shortener_DB`.`urls` TO `shortener`@`%`;

--- a/tools.go
+++ b/tools.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 )
 
@@ -41,7 +42,11 @@ func readConfig(cfgFile string) error {
 		}
 	}
 	if err != nil {
-		return fmt.Errorf("configuration file '%s' reading/parsing error: %w", cfgFile, err)
+		err = fmt.Errorf("configuration file '%s' reading/parsing error: %w", cfgFile, err)
+		if CONFIG.DSN == "" {
+			return err
+		}
+		log.Println(err)
 	}
 
 	// set default values for optional config variables

--- a/tools.go
+++ b/tools.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -25,28 +24,24 @@ var CONFIG Config
 // readConfig reads config and also tries to get the DB connection string from environment variable
 func readConfig(cfgFile string) error {
 
+	// try to read DSN from evirinment
+	CONFIG.DSN = os.Getenv("URLSHORTENER_DSN")
+
 	// read config file into buffer
 	buf, err := ioutil.ReadFile(cfgFile)
 	if err == nil {
 		// parse config file
 		err = json.Unmarshal(buf, &CONFIG)
-		if err == nil {
-			// check mandatory config variable
-			if CONFIG.DSN == "" {
-				// try to read it from evirinment
-				CONFIG.DSN = os.Getenv("URLSHORTENER_DSN")
-				if CONFIG.DSN == "" {
-					return errors.New("DSN is not set")
-				}
-			}
-		}
 	}
+
+	// log config readin/parsing error
 	if err != nil {
-		err = fmt.Errorf("configuration file '%s' reading/parsing error: %w", cfgFile, err)
-		if CONFIG.DSN == "" {
-			return err
-		}
-		log.Println(err)
+		log.Printf("Warning: configuration file '%s' reading/parsing error: %s\n", cfgFile, err)
+	}
+
+	// check mandatory config variable DSN
+	if CONFIG.DSN == "" {
+		return errors.New("DSN is not set")
 	}
 
 	// set default values for optional config variables

--- a/tools.go
+++ b/tools.go
@@ -29,18 +29,19 @@ func readConfig(cfgFile string) error {
 	if err == nil {
 		// parse config file
 		err = json.Unmarshal(buf, &CONFIG)
-		if err != nil {
-			return fmt.Errorf("configuration file '%s' parsing error: %w", cfgFile, err)
+		if err == nil {
+			// check mandatory config variable
+			if CONFIG.DSN == "" {
+				// try to read it from evirinment
+				CONFIG.DSN = os.Getenv("URLSHORTENER_DSN")
+				if CONFIG.DSN == "" {
+					return errors.New("DSN is not set")
+				}
+			}
 		}
 	}
-
-	// check mandatory config variable
-	if CONFIG.DSN == "" {
-		// try to read it from evirinment
-		CONFIG.DSN = os.Getenv("URLSHORTENER_DSN")
-		if CONFIG.DSN == "" {
-			return errors.New("DSN is not set")
-		}
+	if err != nil {
+		return fmt.Errorf("configuration file '%s' reading/parsing error: %w", cfgFile, err)
 	}
 
 	// set default values for optional config variables
@@ -57,7 +58,7 @@ func readConfig(cfgFile string) error {
 		CONFIG.ShortDomain = "localhost:8080"
 	}
 
-	// do not set CONFIG.Mode as default is 0
+	// do not set CONFIG.Mode as default value is 0
 
 	return nil
 }


### PR DESCRIPTION
/api/v1/expire now takes two parameters: `token` and optional `exp` - new expiration for token (in days, counting from request time and date). If second parameter is not passed then token is marked as expired